### PR TITLE
Enabling read-by-uuid for records with binary uuids

### DIFF
--- a/app.go
+++ b/app.go
@@ -39,6 +39,7 @@ func main() {
 	app := cli.App("restorage", "A RESTful storage API with pluggable backends")
 	port := app.IntOpt("port", 8080, "Port to listen on")
 	idMap := app.StringOpt("id-map", "test1:uuid,test2:id,...", "Mapping of collection name to identifier property name")
+	isBinaryUUID := app.BoolOpt("binary-uuid", false, "Is the configured id in a binary format?")
 
 	app.Command("elastic", "use the elastic search backend", func(cmd *cli.Cmd) {
 		url := cmd.StringArg("URL", "", "elastic search endpoint url")
@@ -54,7 +55,7 @@ func main() {
 		dbname := cmd.StringOpt("dbname", "store", "database name")
 		cmd.Action = func() {
 			colls := parseCollections(*idMap)
-			serve(NewMongoEngine(*dbname, colls, *hostports), colls, *port)
+			serve(NewMongoEngine(*dbname, colls, *hostports, *isBinaryUUID), colls, *port)
 		}
 
 	})

--- a/app.go
+++ b/app.go
@@ -39,7 +39,6 @@ func main() {
 	app := cli.App("restorage", "A RESTful storage API with pluggable backends")
 	port := app.IntOpt("port", 8080, "Port to listen on")
 	idMap := app.StringOpt("id-map", "test1:uuid,test2:id,...", "Mapping of collection name to identifier property name")
-	isBinaryUUID := app.BoolOpt("binary-uuid", false, "Is the configured id in a binary format?")
 
 	app.Command("elastic", "use the elastic search backend", func(cmd *cli.Cmd) {
 		url := cmd.StringArg("URL", "", "elastic search endpoint url")
@@ -53,9 +52,10 @@ func main() {
 	app.Command("mongo", "use the mongodb backend", func(cmd *cli.Cmd) {
 		hostports := cmd.StringArg("HOSTS", "", "hostname1:port1,hostname2:port2,...")
 		dbname := cmd.StringOpt("dbname", "store", "database name")
+		isBinaryId := cmd.BoolOpt("binary-identity", false, "Is the configured id in a binary format?")
 		cmd.Action = func() {
 			colls := parseCollections(*idMap)
-			serve(NewMongoEngine(*dbname, colls, *hostports, *isBinaryUUID), colls, *port)
+			serve(NewMongoEngine(*dbname, colls, *hostports, *isBinaryId), colls, *port)
 		}
 
 	})

--- a/engine_mgo.go
+++ b/engine_mgo.go
@@ -13,9 +13,9 @@ import (
 )
 
 type mongoEngine struct {
-	session      *mgo.Session
-	dbName       string
-	isBinaryUUID bool
+	session    *mgo.Session
+	dbName     string
+	isBinaryId bool
 }
 
 func (eng mongoEngine) Close() {
@@ -23,7 +23,7 @@ func (eng mongoEngine) Close() {
 }
 
 // NewMongoEngine returns an Engine based on a mongodb database backend
-func NewMongoEngine(dbName string, collections Collections, hostPorts string, isBinaryUUID bool) Engine {
+func NewMongoEngine(dbName string, collections Collections, hostPorts string, isBinaryId bool) Engine {
 	log.Printf("connecting to mongodb '%s'\n", hostPorts)
 	s, err := mgo.Dial(hostPorts)
 	if err != nil {
@@ -31,9 +31,9 @@ func NewMongoEngine(dbName string, collections Collections, hostPorts string, is
 	}
 	s.SetMode(mgo.Monotonic, true)
 	eng := &mongoEngine{
-		session:      s,
-		dbName:       dbName,
-		isBinaryUUID: isBinaryUUID,
+		session:    s,
+		dbName:     dbName,
+		isBinaryId: isBinaryId,
 	}
 
 	for _, coll := range collections {
@@ -98,9 +98,9 @@ func (eng *mongoEngine) Load(collection Collection, id string) (bool, Document, 
 	var content Document
 
 	var err error
-	if eng.isBinaryUUID {
-		binaryUUID := bson.Binary{Kind: 0x04, Data: []byte(uuid.Parse(id))}
-		err = c.Find(bson.M{collection.idPropertyName: binaryUUID}).One(&content)
+	if eng.isBinaryId {
+		binaryId := bson.Binary{Kind: 0x04, Data: []byte(uuid.Parse(id))}
+		err = c.Find(bson.M{collection.idPropertyName: binaryId}).One(&content)
 	} else {
 		err = c.Find(bson.M{collection.idPropertyName: id}).One(&content)
 	}
@@ -173,8 +173,8 @@ func (eng mongoEngine) Ids(collection Collection, stopchan chan struct{}) (chan 
 func getUUIDString(uuidValue interface{}) string {
 	if uuidString, ok := uuidValue.(string); ok {
 		return uuidString
-	} else if binaryUUID, ok := uuidValue.(bson.Binary); ok {
-		return uuid.UUID(binaryUUID.Data).String()
+	} else if binaryId, ok := uuidValue.(bson.Binary); ok {
+		return uuid.UUID(binaryId.Data).String()
 	} else {
 		fmt.Printf("UUID field is in an unknown format!\n %# v", pretty.Formatter(uuidValue))
 		return ""

--- a/engine_mgo.go
+++ b/engine_mgo.go
@@ -2,18 +2,20 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"log"
 
+	"fmt"
+
 	"github.com/kr/pretty"
+	"github.com/pborman/uuid"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"github.com/pborman/uuid"
 )
 
 type mongoEngine struct {
-	session *mgo.Session
-	dbName  string
+	session      *mgo.Session
+	dbName       string
+	isBinaryUUID bool
 }
 
 func (eng mongoEngine) Close() {
@@ -21,7 +23,7 @@ func (eng mongoEngine) Close() {
 }
 
 // NewMongoEngine returns an Engine based on a mongodb database backend
-func NewMongoEngine(dbName string, collections Collections, hostPorts string) Engine {
+func NewMongoEngine(dbName string, collections Collections, hostPorts string, isBinaryUUID bool) Engine {
 	log.Printf("connecting to mongodb '%s'\n", hostPorts)
 	s, err := mgo.Dial(hostPorts)
 	if err != nil {
@@ -29,8 +31,9 @@ func NewMongoEngine(dbName string, collections Collections, hostPorts string) En
 	}
 	s.SetMode(mgo.Monotonic, true)
 	eng := &mongoEngine{
-		session: s,
-		dbName:  dbName,
+		session:      s,
+		dbName:       dbName,
+		isBinaryUUID: isBinaryUUID,
 	}
 
 	for _, coll := range collections {
@@ -93,7 +96,15 @@ func (eng *mongoEngine) Count(collection Collection) int {
 func (eng *mongoEngine) Load(collection Collection, id string) (bool, Document, error) {
 	c := eng.session.DB(eng.dbName).C(collection.name)
 	var content Document
-	err := c.Find(bson.M{collection.idPropertyName: id}).One(&content)
+
+	var err error
+	if eng.isBinaryUUID {
+		binaryUUID := bson.Binary{Kind: 0x04, Data: []byte(uuid.Parse(id))}
+		err = c.Find(bson.M{collection.idPropertyName: binaryUUID}).One(&content)
+	} else {
+		err = c.Find(bson.M{collection.idPropertyName: id}).One(&content)
+	}
+
 	if err == mgo.ErrNotFound {
 		return false, Document{}, nil
 	}
@@ -164,7 +175,7 @@ func getUUIDString(uuidValue interface{}) string {
 		return uuidString
 	} else if binaryUUID, ok := uuidValue.(bson.Binary); ok {
 		return uuid.UUID(binaryUUID.Data).String()
-	} else{
+	} else {
 		fmt.Printf("UUID field is in an unknown format!\n %# v", pretty.Formatter(uuidValue))
 		return ""
 	}


### PR DESCRIPTION
- added switch for binary uuid
- defaults to false so existing instances will not be affected
- only used for read by uuid so far
