### PR TITLE
Return a string id even if the DB one is binary

### DIFF
--- a/engine_mgo.go
+++ b/engine_mgo.go
@@ -112,6 +112,9 @@ func (eng *mongoEngine) Load(collection Collection, id string) (bool, Document, 
 		return false, Document{}, err
 	}
 	cleanup(content)
+	if eng.isBinaryId {
+		content["uuid"] = id
+	}
 	return true, content, nil
 }
 


### PR DESCRIPTION
- this way we don't have to deal with the binary id at all, and it mimics the nativerw output, which does the same
